### PR TITLE
Warning about mixing $SCHED paths between pySCHED & NRAO SCHED

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ sudo apt-get install git
 
 ### Using pySCHED within a SCHED environment
 
-The aforementioned usage can potentially generate some issues when pySCHED runs in an environment where the variable `$SCHED` is set for the NRAO SCHED program. If `$SCHED` is set to the path that points to the NRAO SCHED directory, then pySCHED would try to read the catalogs under such directory. In this case, pySCHED would be unable to download the most up-to-date catalogs and may fail.
+The aforementioned usage can potentially generate some issues when pySCHED runs in an environment where the variable `$SCHED` is set for the NRAO SCHED program. If `$SCHED` is indeed set to the path that points to the NRAO SCHED directory, then pySCHED would try to read the catalogs under such directory. In this case, pySCHED would be unable to download the most up-to-date catalogs and may fail.
 
 We therefore recommend to unset such variable before running pySCHED (which would then use the default `~/.pysched` directory) or set it to an alternate directory unrelated to the NRAO SCHED path.
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,14 @@ sudo apt-get install git
 ```
 
 
+### Using pySCHED within a SCHED environment
+
+The aforementioned usage can potentially generate some issues when pySCHED runs in an environment where the variable `$SCHED` is set for the NRAO SCHED program. If `$SCHED` is set to the path that points to the NRAO SCHED directory, then pySCHED would try to read the catalogs under such directory. In this case, pySCHED would be unable to download the most up-to-date catalogs and may fail.
+
+We therefore recommend to unset such variable before running pySCHED (which would then use the default `~/.pysched` directory) or set it to an alternate directory unrelated to the NRAO SCHED path.
+
+
+
 
 # Release history
 


### PR DESCRIPTION
README is updated with a case that is likely to happen often for a regular user.

If NRAO SCHED is installed in the system, the user would have set by default the `$SCHED` environment variable to its location. In that case, and without noticing it, pySCHED would be trying to read the information from the NRAO SCHED catalogs, instead of the ones updated from pySCHED itself.

This would typically through several errors that otherwise would not happen. It can be helpful for a user to be aware of this and then set (or unset) properly the `$SCHED` variable.


PD: not completely sure that the sentence "pySCHED would then be unable to update the catalogs" is completely right. Please feel free to change it otherwise. But it reflects the case that pySCHED would retrieve the information from such catalogs and being unable to find the more recent setups.