### PR TITLE
Update pip version constraint in pySCHED.yaml

### DIFF
--- a/pySCHED.yaml
+++ b/pySCHED.yaml
@@ -5,7 +5,7 @@ dependencies:
   - git
   - numpy>=1.16, <1.24
   - setuptools>=24.3, <60
-  - pip>=9
+  - pip>=9, <25.3
   - conda-forge::pyqt
   - pip:
     - pythonSCHED


### PR DESCRIPTION
Places an upper bound on the pip dependency to prevent newer versions from being installed where `setup.py` fails.
See #32 for more details